### PR TITLE
docs(readme): document Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ This repository contains binary releases for LazyTyper.
 
 ## Download
 Visit the [Releases](https://github.com/oldcai/LazyTyper-releases/releases) page to download the latest version.
+
+## Homebrew
+Install the stable macOS release from the vendor-maintained [Homebrew tap](https://github.com/oldcai/homebrew-lazytyper):
+
+```sh
+brew install --cask oldcai/lazytyper/lazytyper
+```
+
+The cask tracks stable macOS releases, while nightly builds remain on the [Releases](https://github.com/oldcai/LazyTyper-releases/releases) page.


### PR DESCRIPTION
## Summary
- Add the exact Homebrew cask installation command to `README.md`.
- Link the vendor-maintained tap and clarify that the cask tracks stable macOS releases while nightly builds remain on the Releases page.

Addresses oldcai/LazyTyper#821

## Verification
- `git diff --check` passed.
- Deterministic checks passed for the exact command, tap URL, stable/nightly wording, and README-only diff scope.
- No repository-native Markdown/documentation check configuration is present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no runtime or security impact.
> 
> **Overview**
> Adds a **Homebrew** section to `README.md` with the stable macOS install command (`brew install --cask oldcai/lazytyper/lazytyper`), a link to the vendor tap, and a note that the cask is for stable releases while nightlies stay on the Releases page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa6230382b117d8f2954e7fac536045ad33bda2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->